### PR TITLE
fix: do not throw if chatid failed with exception

### DIFF
--- a/NotificationService/TelegramBot/TelegramNotificationExtensions.cs
+++ b/NotificationService/TelegramBot/TelegramNotificationExtensions.cs
@@ -1,0 +1,19 @@
+using Telegram.Bot;
+using Telegram.Bot.Types;
+namespace NotificationService.TelegramBot;
+
+internal static class TelegramNotificationExtensions
+{
+    internal static async Task<(Chat? Chat, Exception? Exception)> TryGetChatByUserId(this Telegram.Bot.TelegramBotClient botClient, long userId)
+    {
+        try
+        {
+            var chat = await botClient.GetChatAsync(userId);
+            return (chat, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, ex);
+        }
+    }
+}


### PR DESCRIPTION
While consuming NewPostPublished event which should lead to notification sent to all subscribed users we got
![image](https://github.com/user-attachments/assets/966aa0dd-c397-4698-bb55-e27e5eea2203)

exception by telegram client could be caused by different possible reasons: blocked chat, user no longer exists etc.
What we should do is handle this exception gracefully, skip this user and continue our notification process.